### PR TITLE
Add `npm run bump` to automate version bumping

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "test": "NODE_ENV=unit node node_modules/.bin/istanbul test -- _mocha -r co-mocha",
     "test-oracle": "NOTARY_DB_ENV=oracledev DYLD_LIBRARY_PATH=/opt/oracle/instantclient NODE_ENV=unit node node_modules/.bin/istanbul test -- _mocha -r co-mocha",
     "test-oracle-ci": "NOTARY_DB_ENV=oracleci LD_LIBRARY_PATH=/opt/oracle/instantclient NODE_ENV=unit node node_modules/.bin/istanbul test -- _mocha -r co-mocha",
-    "preversion": "npm test",
-    "postversion": "git push --follow-tags"
+    "bump": "version-bump"
   },
   "keywords": [
     "consensus",
@@ -34,7 +33,7 @@
     "co-request": "^1.0.0",
     "constitute": "^1.2.0",
     "five-bells-condition": "^2.0.0",
-    "five-bells-shared": "^9.1.2",
+    "five-bells-shared": "^11.2.0",
     "knex": "^0.9.0",
     "koa": "^1.0.0",
     "koa-mag": "^1.1.0",


### PR DESCRIPTION
Requires interledger/five-bells-shared#100