### PR TITLE
Fix: timerWorker should expire cases (RILP-371)

### DIFF
--- a/src/lib/caseExpiryMonitor.js
+++ b/src/lib/caseExpiryMonitor.js
@@ -3,7 +3,6 @@
 const moment = require('moment')
 const TimeQueue = require('./timeQueue')
 const NotificationWorker = require('./notificationWorker')
-const DB = require('./db')
 const Log = require('./log')
 const ExpiredCaseError = require('../errors/expired-case-error')
 const CaseFactory = require('../models/db/case')
@@ -11,11 +10,10 @@ const co = require('co')
 const knex = require('./knex')
 
 class CaseExpiryMonitor {
-  static constitute () { return [ TimeQueue, NotificationWorker, DB, Log, CaseFactory ] }
-  constructor (timeQueue, notificationWorker, db, log, Case) {
+  static constitute () { return [ TimeQueue, NotificationWorker, Log, CaseFactory ] }
+  constructor (timeQueue, notificationWorker, log, Case) {
     this.queue = timeQueue
     this.notificationWorker = notificationWorker
-    this.db = db
     this.log = log('caseExpiryMonitor')
     this.Case = Case
   }

--- a/src/lib/timerWorker.js
+++ b/src/lib/timerWorker.js
@@ -32,14 +32,14 @@ class TimerWorker {
   }
 
   * processTimeQueue () {
-    // Process expired transfers
+    // Process expired cases
     yield this.caseExpiryMonitor.processExpiredCases()
 
     // Set the timer to the earliest date on the timeQueue
     if (this.timeout) {
       clearTimeout(this.timeout)
-      this.processTimeQueueSoon()
     }
+    this.processTimeQueueSoon()
   }
 
   processTimeQueueSoon () {

--- a/test/caseSpec.js
+++ b/test/caseSpec.js
@@ -265,6 +265,18 @@ describe('Cases', function () {
       yield notificationWorker.processNotificationQueue()
 
       putNotification.done()
+
+      yield this.request()
+        .get(exampleCase.id)
+        .expect(200)
+        .expect(_.assign({}, exampleCase, {
+          notaries: [
+            'http://localhost'
+          ]
+        }, {
+          state: 'rejected'
+        }))
+        .end()
     })
   })
 })


### PR DESCRIPTION
This is a fixes an issue in which cases were not expired. The bug was kind of insidious because the test case didn't catch it. The test manually calls `timerWorker.processTimeQueue()` to expires the case. When the app is running, this function is invoked via a setTimeout. Ideally, we'd set up the test exactly as the app is run: instead of calling `timerWorker.processTimeQueue()` multiple times, we'd call `timerWorker.start()` once, send a case to the notary, and wait for it to expire. Unfortunately, I couldn't get the fake timers to play nicely with `timerWorker.js`. @justmoon may have some ideas.

A nearly identical time queue is also used to expire transfers in the ledger. I think it would make sense to move this time queue functionality to five-bell-shared, where we can test it all in one place, and avoid bugs like this (it was working in the ledger, but not on the notary, due to a one line difference).