### PR TITLE
[CI] Parallelize Notary tests and use ci-npm-publish task from

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:4-slim
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY . /usr/src/app
+
+EXPOSE 3000
+
+CMD [ "npm", "start" ]

--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,8 @@ machine:
     version: 4.3.0
   services:
     - docker
+    - mysql
+    - postgresql
   environment:
     OCI_HOME: /opt/oracle/instantclient
     OCI_LIB_DIR: $OCI_HOME
@@ -13,44 +15,20 @@ machine:
     AWS_ACCESS_KEY_ID: AKIAIVUX7BG4NS7A2UHQ
 dependencies:
   pre:
-    # Install Oracle
-    - docker pull wnameless/oracle-xe-11g
-    - docker run -d -p 49160:22 -p 49161:1521 wnameless/oracle-xe-11g
-    # Download and unzip Oracle library
-    - aws s3 cp s3://ilp-server-ci-files/instantclient-sdk-linux.x64-12.1.0.2.0.zip .
-    - aws s3 cp s3://ilp-server-ci-files/instantclient-basic-linux.x64-12.1.0.2.0.zip .
-    - unzip instantclient-sdk-linux.x64-12.1.0.2.0.zip
-    - unzip instantclient-basic-linux.x64-12.1.0.2.0.zip
-    # Need symlinks from .so.12.1 to .so
-    - ln -s libocci.so.12.1 instantclient_12_1/libocci.so
-    - ln -s libclntsh.so.12.1 instantclient_12_1/libclntsh.so
-    - sudo mkdir -p /opt/oracle
-    - sudo cp -r instantclient_12_1 /opt/oracle/instantclient
-
-  post:
-    - npm i strong-oracle
-    # Check for node_modules/strong-oracle explicitly because even if installation of it fails, npm doesn't catch it.
-    - if [[ ! -d node_modules/strong-oracle ]] ; then echo 'node_modules/strong-oracle is not there, return error.' ; exit 1 ; fi
+    - mkdir -p ~/.oracle
+  cache_directories:
+    - "~/.oracle"
 test:
   override:
-    # Run lint
-    - npm run lint
-    # Run unit tests on SQLite
-    - npm test
-    # Run unit tests on Oracle
-    - npm run test-oracle-ci
-    # Run integration test suite
-    - npm run integration
-    # Generate API documentation
-    - npm run apidoc
+    - scripts/ci-test.sh "$CIRCLE_NODE_INDEX" "$CIRCLE_NODE_TOTAL":
+        parallel: true
 deployment:
   production:
     branch: master
     commands:
-      # Push NPM package if not yet published
-      - mv npmrc-env .npmrc
-      - if [ -z "$(npm info $(npm ls --depth=-1 2>/dev/null | head -1 | cut -f 1 -d " ") 2>/dev/null)" ] ; then npm publish ; fi
+      - scripts/ci-publish.sh
 
 general:
   artifacts:
+    - "coverage/lcov-report"
     - "apidoc-out"

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "apidoc": "apidoc -o apidoc-out -i src/controllers/",
     "test": "istanbul test -- _mocha",
     "test-oracle": "NOTARY_UNIT_DB_URI='oracle://system:oracle@192.168.99.100:49161/' DYLD_LIBRARY_PATH=/opt/oracle/instantclient LD_LIBRARY_PATH=/opt/oracle/instantclient node node_modules/.bin/istanbul test -- _mocha",
-    "test-oracle-ci": "NOTARY_UNIT_DB_URI='oracle://system:oracle@192.168.99.100:49161/' DYLD_LIBRARY_PATH=/opt/oracle/instantclient LD_LIBRARY_PATH=/opt/oracle/instantclient node node_modules/.bin/istanbul test -- _mocha",
     "bump": "version-bump",
-    "integration": "integration all"
+    "integration": "integration all",
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "ci-npm-publish": "ci-publish"
   },
   "keywords": [
     "consensus",
@@ -34,7 +35,7 @@
     "co-request": "^1.0.0",
     "constitute": "^1.2.0",
     "five-bells-condition": "^2.0.0",
-    "five-bells-shared": "^12.4.0",
+    "five-bells-shared": "^13.0.0",
     "knex": "^0.9.0",
     "koa": "^1.0.0",
     "koa-mag": "^1.1.0",
@@ -47,11 +48,18 @@
     "priorityqueuejs": "^1.0.0",
     "tweetnacl": "^0.13.2"
   },
+  "optionalDependencies": {
+    "mysql": "^2.9.0",
+    "pg": "^4.4.1",
+    "sqlite3": "^3.1.0",
+    "tedious": "^1.12.3"
+  },
   "devDependencies": {
     "apidoc": "^0.13.1",
     "chai": "^3.4.1",
     "co-mocha": "^1.1.2",
     "co-supertest": "0.0.10",
+    "coveralls": "^2.11.9",
     "eslint": "^2.0.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-standard": "^1.3.2",
@@ -61,7 +69,7 @@
     "mocha": "^2.3.4",
     "nock": "^3.1.1",
     "sinon": "^1.17.2",
-    "sqlite3": "^3.1.1",
+    "spec-xunit-file": "0.0.1-3",
     "supertest": "^1.1.0"
   }
 }

--- a/scripts/ci-publish.sh
+++ b/scripts/ci-publish.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -ex
+
+uploadCoverage() {
+  # On parallel builds, only run coverage command on the container that ran the
+  # SQLite tests with coverage
+  if [ -d coverage ]; then
+    # Extract test results
+    cp coverage/xunit.xml "${CIRCLE_TEST_REPORTS}/"
+
+    # Upload coverage data
+    docker run --volumes-from notary-test-sqlite \
+      -e COVERALLS_REPO_TOKEN="${COVERALLS_REPO_TOKEN}" \
+      interledger/five-bells-notary npm run coveralls
+  fi
+}
+
+npmPublish() {
+  npm run ci-npm-publish
+}
+
+dockerPush() {
+  # Push Docker image tagged latest and tagged with commit descriptor
+  sed "s/<AUTH>/${DOCKER_TOKEN}/" < "dockercfg-template" > ~/.dockercfg
+  docker tag interledger/five-bells-notary:latest interledger/five-bells-notary:"$(git describe)"
+  docker push interledger/five-bells-notary:latest
+  docker push interledger/five-bells-notary:"$(git describe)"
+}
+
+npmPublish
+uploadCoverage
+dockerPush
+

--- a/scripts/ci-test.sh
+++ b/scripts/ci-test.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+set -ex
+set -o pipefail
+
+NODE_INDEX="$1"
+TOTAL_NODES="$2"
+ORACLE_DIR="$HOME/.oracle"
+
+lint() {
+  npm run lint
+}
+
+integrationtest() {
+  npm run integration
+}
+
+apidoc() {
+  npm run apidoc
+}
+
+dockerBuild() {
+  docker build -t interledger/five-bells-notary .
+}
+
+mysqltest() {
+  mysql -u ubuntu -e 'DROP DATABASE circle_test;'
+  mysql -u ubuntu -e 'CREATE DATABASE circle_test;'
+  docker run --name=notary-test-mysql -it --net=host \
+    -e NOTARY_UNIT_DB_URI=mysql://ubuntu@localhost/circle_test \
+    interledger/five-bells-notary npm test
+}
+
+postgrestest() {
+  psql -U ubuntu -c 'DROP DATABASE circle_test;'
+  psql -U ubuntu -c 'CREATE DATABASE circle_test;'
+  docker run --name=notary-test-postgres -it --net=host \
+    -e NOTARY_UNIT_DB_URI=postgres://ubuntu@localhost/circle_test \
+    interledger/five-bells-notary npm test
+}
+
+sqlitetest() {
+  # Run tests with coverage (SQLite)
+  mkdir coverage
+  docker run --name=notary-test-sqlite -it --net=host \
+    -e NOTARY_UNIT_DB_URI=sqlite:// \
+    -e XUNIT_FILE=coverage/xunit.xml \
+    -v "$PWD"/coverage:/usr/src/app/coverage \
+    interledger/five-bells-notary sh -c 'npm test --coverage -- -R spec-xunit-file'
+  # Extract test results
+  cp coverage/xunit.xml "${CIRCLE_TEST_REPORTS}/"
+}
+
+oracletest() {
+  # Install Oracle
+  docker pull wnameless/oracle-xe-11g
+  docker run -d -p 49160:22 -p 49161:1521 wnameless/oracle-xe-11g
+  # Download and unzip Oracle library
+  mkdir -p "$ORACLE_DIR"
+
+  local clientSDK="instantclient-sdk-linux.x64-12.1.0.2.0.zip"
+  if [ ! -f "$ORACLE_DIR/$clientSDK" ]; then
+    (
+    cd "$ORACLE_DIR" || exit 1
+
+    aws s3 cp s3://ilp-server-ci-files/"$clientSDK" .
+    aws s3 cp s3://ilp-server-ci-files/instantclient-basic-linux.x64-12.1.0.2.0.zip .
+    unzip $clientSDK
+    unzip instantclient-basic-linux.x64-12.1.0.2.0.zip
+    # Need symlinks from .so.12.1 to .so
+    ln -s libocci.so.12.1 instantclient_12_1/libocci.so
+    ln -s libclntsh.so.12.1 instantclient_12_1/libclntsh.so
+    sudo mkdir -p /opt/oracle
+    sudo cp -r instantclient_12_1 /opt/oracle/instantclient
+
+    cd -
+    )
+  fi
+
+  npm i strong-oracle
+  # Check for node_modules/strong-oracle explicitly because even if installation of it fails, npm doesn't catch it.
+  if [[ ! -d node_modules/strong-oracle ]]; then 
+    echo 'node_modules/strong-oracle is not there, return error.'
+    exit 1
+  fi
+
+  LEDGER_UNIT_DB_URI='oracle://system:oracle@localhost:49161/' \
+    LD_LIBRARY_PATH=/opt/oracle/instantclient \
+    npm test
+}
+
+
+oneNode() {
+  lint
+  dockerBuild
+  sqlitetestest
+  integrationtest
+  mysqltest
+  postgrestest
+  oracletest
+  apidoc
+}
+
+twoNodes() {
+  case "$NODE_INDEX" in
+    0) lint; dockerBuild; sqlitetest integrationtest; mysqltest;;
+    1) dockerBuild; oracletest; postgrestest; apidoc;;
+    *) echo "ERROR: invalid usage"; exit 2;;
+  esac
+}
+
+threeNodes() {
+  case "$NODE_INDEX" in
+    0) lint; dockerBuild; sqlitetest integrationtest;;
+    1) dockerBuild; postgrestest; mysqltest;;
+    2) dockerBuild; oracletest; apidoc;;
+    *) echo "ERROR: invalid usage"; exit 2;;
+  esac
+}
+
+fourNodes() {
+  case "$NODE_INDEX" in
+    0) dockerBuild; sqlitetest; postgrestest;;
+    1) integrationtest;;
+    2) lint; dockerBuild; mysqltest; apidoc;;
+    3) oracletest;;
+    *) echo "ERROR: invalid usage"; exit 2;;
+  esac
+}
+
+case "$TOTAL_NODES" in
+  "") oneNode;;
+  1) oneNode;;
+  2) twoNodes;;
+  3) threeNodes;;
+  4) fourNodes;;
+  *) echo "ERROR: invalid usage"; exit 2;;
+esac


### PR DESCRIPTION
five-bells-shared

Using
https://github.com/interledger/five-bells-shared/blob/master/bin/ci-publish.sh
to safely publish npm modules

Also adds testing on mysql and postgres. Publishing apidoc and coveralls.

Blocked by:
- Requires docker container to be registered
- Env variables for docker set in CircleCI