### PR TITLE
[FIX] Use co-mocha for testing

### DIFF
--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+-r co-mocha --timeout 150000


### PR DESCRIPTION
Looks like the `co-mocha` flag was removed [here](https://github.com/interledger/five-bells-notary/pull/47/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R15). This commit adds it back in the `mocha.opts` file.