### PR TITLE
Load schemas more robustly

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -22,9 +22,13 @@ module.exports = class App {
     this.notificationWorker = notificationWorker
     this.timerWorker = timerWorker
 
+    const notarySchemaPath = path.join(__dirname, '/../../schemas')
+    const conditionSchemaPath =
+      path.resolve(path.dirname(require.resolve('five-bells-condition')), 'schemas')
+
     validator.loadSharedSchemas()
-    validator.loadSchemasFromDirectory(path.join(__dirname, '/../../schemas'))
-    validator.loadSchemasFromDirectory(path.join(__dirname, '/../../node_modules/five-bells-condition/schemas'))
+    validator.loadSchemasFromDirectory(notarySchemaPath)
+    validator.loadSchemasFromDirectory(conditionSchemaPath)
 
     const app = this.app = koa()
     app.use(logger({mag: log('http')}))


### PR DESCRIPTION
Previously, the schema loading code assumed that the five-bells-condition module was installed beneath the five-bells-notary module. With NPM 3 this is often not the case.

This fix uses Node's native module resolution to figure out where five-bells-condition is, then loads the schemas from there.