### PR TITLE
Add eslint-plugin-promise to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "coveralls": "^2.11.9",
     "eslint": "^2.0.0",
     "eslint-config-standard": "^5.1.0",
+    "eslint-plugin-promise": "^1.1.0",
     "eslint-plugin-standard": "^1.3.2",
     "five-bells-integration-test": "^1.4.0",
     "istanbul": "^0.4.0",


### PR DESCRIPTION
This is needed to bump version when using npm 3.8.5