### PR TITLE
Ability to add notification targets to an existing case.

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "co-request": "^1.0.0",
     "constitute": "^1.2.0",
     "five-bells-condition": "^3.1.0",
-    "five-bells-shared": "^14.0.0",
+    "five-bells-shared": "^16.1.0",
     "knex": "^0.9.0",
     "koa": "^1.0.0",
     "koa-mag": "^1.1.0",

--- a/schemas/AdditionalTargets.json
+++ b/schemas/AdditionalTargets.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "title": "AdditionalTargets",
+  "description": "A list of targets to add to a case",
+  "type": "array",
+  "items": {
+    "$ref": "Iri.json"
+  }
+}

--- a/schemas/Case.json
+++ b/schemas/Case.json
@@ -1,4 +1,4 @@
-  {
+{
   "$schema": "http://json-schema.org/draft-04/schema",
   "title": "Case",
   "description": "A specific binary decision to be notarized",

--- a/src/controllers/cases.js
+++ b/src/controllers/cases.js
@@ -1,10 +1,11 @@
 'use strict'
 
 const parse = require('co-body')
-const request = require('five-bells-shared/utils/request')
 const CasesFactory = require('../models/cases')
-CasesControllerFactory.constitute = [CasesFactory]
-function CasesControllerFactory (Cases) {
+const Validator = require('five-bells-shared').Validator
+
+CasesControllerFactory.constitute = [CasesFactory, Validator]
+function CasesControllerFactory (Cases, validator) {
   return class CasesController {
     /**
      * @api {get} /cases/:id Get information about a case
@@ -20,7 +21,7 @@ function CasesControllerFactory (Cases) {
      */
     static * getResource () {
       const id = this.params.id.toLowerCase()
-      request.validateUriParameter('id', id, 'Uuid')
+      validator.validateUriParameter('id', id, 'Uuid')
       this.body = yield Cases.getCase(id)
     }
 
@@ -42,7 +43,7 @@ function CasesControllerFactory (Cases) {
      */
     static * putResource () {
       const id = this.params.id.toLowerCase()
-      request.validateUriParameter('id', id, 'Uuid')
+      validator.validateUriParameter('id', id, 'Uuid')
       const result = yield Cases.putCase(id, this.body)
       this.body = result.caseData
       this.status = result.existed ? 200 : 201
@@ -63,7 +64,29 @@ function CasesControllerFactory (Cases) {
      */
     static * putFulfillmentResource () {
       const id = this.params.id.toLowerCase()
+      validator.validateUriParameter('id', id, 'Uuid')
       this.body = yield Cases.fulfillCase(id, yield parse.text(this))
+      this.status = 200
+    }
+
+    /**
+     * @api {post} /cases/:id/targets Add a notification target
+     * @apiName PostCaseTarget
+     * @apiGroup Case
+     * @apiVersion 1.0.0
+     *
+     * @apiDescription Add an additional notification target to an existing case
+     * @apiParam {String} id UUID of the case
+     * @apiParam {JSON} body
+     *
+     * @return {void}
+     */
+    static * postNotificationTargetResource () {
+      const id = this.params.id.toLowerCase()
+      validator.validateUriParameter('id', id, 'Uuid')
+      const targets = yield validator.validateBody(this, 'AdditionalTargets')
+
+      this.body = yield Cases.addNotificationTarget(id, targets)
       this.status = 200
     }
   }

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -24,6 +24,7 @@ module.exports = class Router {
     this.router.get('/cases/:id', cases.getResource)
     this.router.put('/cases/:id', CaseModel.createBodyParser(), cases.putResource)
     this.router.put('/cases/:id/fulfillment', cases.putFulfillmentResource)
+    this.router.post('/cases/:id/targets', cases.postNotificationTargetResource)
   }
 
   attach (app) {

--- a/src/models/cases.js
+++ b/src/models/cases.js
@@ -72,5 +72,24 @@ function CasesFactory (Case, log, notificationWorker, caseExpiryMonitor) {
         return caseInstance.getDataExternal()
       })
     }
+
+    static * addNotificationTarget (caseId, targetUris) {
+      return yield db.transaction(function * (transaction) {
+        const caseInstance = yield db.getCase(Case, caseId, {transaction})
+        if (!caseInstance) {
+          throw new UnprocessableEntityError('Unknown case ID ' + caseId)
+        } else if (caseInstance.isFinalized()) {
+          throw new UnprocessableEntityError(
+            'Case ' + caseId + ' is already finalized')
+        }
+
+        caseInstance.notification_targets =
+          caseInstance.notification_targets.concat(targetUris)
+
+        yield db.updateCase(caseInstance, {transaction})
+
+        return caseInstance.getDataExternal()
+      })
+    }
   }
 }

--- a/src/models/db/case.js
+++ b/src/models/db/case.js
@@ -57,6 +57,10 @@ function CaseFactory (uri, validator, container) {
       data.notaries = data.notaries[0]
       return data
     }
+
+    isFinalized () {
+      return this.state === 'executed' || this.state === 'rejected'
+    }
   }
 
   Case.validateExternal = validator.create('Case')

--- a/test/caseSpec.js
+++ b/test/caseSpec.js
@@ -242,6 +242,36 @@ describe('Cases', function () {
     })
   })
 
+  describe('POST /cases/:id/targets', function () {
+    it('should return 200 when successfully adding a new target', function * () {
+      const exampleCase = this.cases.other
+
+      yield this.request()
+        .post(exampleCase.id + '/targets')
+        .send(['http://new.example'])
+        .expect(200)
+        .expect(Object.assign({}, exampleCase, {
+          notification_targets: [
+            'http://ledger.example/transfers/123/fulfillment',
+            'http://new.example'
+          ]
+        }))
+        .end()
+    })
+
+    it('should return 400 when an invalid target is supplied', function * () {
+      const exampleCase = this.cases.other
+
+      const response = yield this.request()
+        .post(exampleCase.id + '/targets')
+        .send({foo: 'bar'})
+        .expect(400)
+        .end()
+
+      expect(response.body.id).to.equal('InvalidBodyError')
+    })
+  })
+
   describe('case notifications', function () {
     it('notifies on case expiration', function * () {
       const exampleCase = this.basicCase


### PR DESCRIPTION
In order to support different types of ledgers, the information that travels with the transfer should be ledger-agnostic. We've identified the minimum set of fields necessary to get the payment to its destination: `destinationAccount` and `destinationAmount`, called the ILP packet or ILP header.

This PR changes the format of the transfer memos to include the ILP header instead of the destination_transfer object as before.

Because the IDs of transfer are generated by each connector now, the connectors need to add the notification targets to the case before they create those transfers. That means the notary needs an endpoint to add notification targets to an existing case.

Related PRs:

interledger/five-bells-connector#160
interledger/five-bells-shared#142
interledger/five-bells-sender#72