### PR TITLE
fix: don't retry notification on >400 error

### DIFF
--- a/src/lib/notificationWorker.js
+++ b/src/lib/notificationWorker.js
@@ -109,6 +109,8 @@ class NotificationWorker {
         body: response
       })
       if (result.statusCode >= 400) {
+        if (result.statusCode < 500) retry = false
+
         this.log.debug(response)
         throw new Error('Remote error for notification ' + result.statusCode,
           result.body)


### PR DESCRIPTION
Given a high enough load, retries will completely saturate both memory and
CPU