### PR TITLE
[FIX] Prevent duplicate notifications

### DIFF
--- a/schemas/AdditionalTargets.json
+++ b/schemas/AdditionalTargets.json
@@ -5,5 +5,6 @@
   "type": "array",
   "items": {
     "$ref": "Iri.json"
-  }
+  },
+  "uniqueItems": true
 }

--- a/schemas/Case.json
+++ b/schemas/Case.json
@@ -28,7 +28,8 @@
       "type": "array",
       "items": {
         "$ref": "Iri.json"
-      }
+      },
+      "uniqueItems": true
     },
     "state": {
       "description": "All cases start in the proposed state and are either executed or rejected",

--- a/src/models/cases.js
+++ b/src/models/cases.js
@@ -20,6 +20,7 @@ const UnmetConditionError = require('five-bells-shared').UnmetConditionError
 const NotFoundError = require('five-bells-shared').NotFoundError
 const InvalidBodyError = require('five-bells-shared/errors/invalid-body-error')
 const validator = require('../lib/validator')
+const _ = require('lodash')
 
 function convertFromExternal (data) {
   // ID is optional on the incoming side
@@ -130,7 +131,7 @@ function CasesFactory (notificationWorker, caseExpiryMonitor) {
         }
 
         caseInstance.notification_targets =
-          caseInstance.notification_targets.concat(targetUris)
+          _.union(caseInstance.notification_targets, targetUris)
 
         yield db.updateCase(caseInstance, {transaction})
 

--- a/test/data/caseInvalidNotificationTargets.json
+++ b/test/data/caseInvalidNotificationTargets.json
@@ -1,0 +1,9 @@
+{
+  "id": "http://localhost/cases/75159fb1-8ed2-4c92-9af7-0f48e2616f47",
+  "execution_condition": "cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7",
+  "expires_at": "2015-11-19T20:27:12.299Z",
+  "notaries": [
+    "http://localhost"
+  ],
+  "notification_targets": ["https://localhost:3001/transfers/123", "https://localhost:3001/transfers/123"]
+}


### PR DESCRIPTION
See RILP-566. If this is the path we want to take, why is `postNotificationTargetResource` POST rather than PUT?