### PR TITLE
feature: Improve logging in Notary

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ NOTARY_DB_SYNC=1 NOTARY_DB_URI='oracle://user:password@docker-machine-ip:port/' 
 ```
 
 `NOTARY_DB_SYNC` is a test setting that creates the database by running the SQL scripts in `./src/sql`. These scripts are not re-runnable. You must drop the database or set `NOTARY_DB_SYNC=0` after the initial run.
+
+
+Configuring log level
+ `NOTARY_LOG_LEVEL` (default: `info`) the allowed levels in order of verbosity are `fatal`, `error`, `warn`, `info`, `debug`, and `trace`

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "author": "Stefan Thomas <justmoon@members.fsf.org>",
   "license": "ISC",
   "dependencies": {
+    "bunyan": "^1.8.1",
     "co": "^4.6.0",
     "co-body": "^4.0.0",
     "co-defer": "^1.0.0",
@@ -40,11 +41,10 @@
     "five-bells-shared": "^17.0.0",
     "knex": "^0.9.0",
     "koa": "^1.0.0",
+    "koa-bunyan-logger": "^1.3.0",
     "koa-mag": "^1.1.0",
     "koa-router": "^5.1.2",
     "lodash": "^3.10.1",
-    "mag": "^0.9.1",
-    "mag-hub": "^0.1.1",
     "moment": "^2.10.6",
     "mysql": "^2.9.0",
     "priorityqueuejs": "^1.0.0"
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "apidoc": "^0.13.1",
+    "bunyan-format": "^0.2.1",
     "chai": "^3.4.1",
     "co-mocha": "^1.1.2",
     "co-supertest": "0.0.10",
@@ -73,6 +74,7 @@
     "nock": "^3.1.1",
     "sinon": "^1.17.2",
     "spec-xunit-file": "0.0.1-3",
-    "supertest": "^1.1.0"
+    "supertest": "^1.1.0",
+    "through2": "^2.0.1"
   }
 }

--- a/src/lib/caseExpiryMonitor.js
+++ b/src/lib/caseExpiryMonitor.js
@@ -3,7 +3,7 @@
 const moment = require('moment')
 const TimeQueue = require('./timeQueue')
 const NotificationWorker = require('./notificationWorker')
-const Log = require('./log')
+const log = require('./log')
 const ExpiredCaseError = require('../errors/expired-case-error')
 const getCaseByUuid = require('../models/db/case').getCaseByUuid
 const updateCase = require('../models/db/case').updateCase
@@ -11,11 +11,11 @@ const co = require('co')
 const knex = require('./knex')
 
 class CaseExpiryMonitor {
-  static constitute () { return [ TimeQueue, NotificationWorker, Log ] }
-  constructor (timeQueue, notificationWorker, log) {
+  static constitute () { return [ TimeQueue, NotificationWorker ] }
+  constructor (timeQueue, notificationWorker) {
     this.queue = timeQueue
     this.notificationWorker = notificationWorker
-    this.log = log('caseExpiryMonitor')
+    this.log = log.create('caseExpiryMonitor')
   }
 
   validateNotExpired (caseInstance) {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -3,4 +3,32 @@
 const Config = require('five-bells-shared').Config
 const envPrefix = 'notary'
 
-module.exports = Config.loadConfig(envPrefix)
+function isRunningTests () {
+  return (
+    process.env.NODE_ENV === 'unit' ||
+    process.argv[0].endsWith('mocha') ||
+    (process.argv.length > 1 && process.argv[0].endsWith('node') &&
+     process.argv[1].endsWith('mocha'))
+   )
+}
+
+function useTestConfig () {
+  return !Config.castBool(process.env.UNIT_TEST_OVERRIDE) && isRunningTests()
+}
+
+function getLogLevel () {
+  if (useTestConfig()) {
+    return 'debug'
+  } else {
+    // https://github.com/trentm/node-bunyan#levels
+    return Config.getEnv(envPrefix, 'LOG_LEVEL') || 'info'
+  }
+}
+
+function getLocalConfig () {
+  const logLevel = getLogLevel()
+  return {
+    logLevel
+  }
+}
+module.exports = Config.loadConfig(envPrefix, getLocalConfig())

--- a/src/lib/log.js
+++ b/src/lib/log.js
@@ -1,8 +1,42 @@
 'use strict'
 
-const hub = require('mag-hub')
-const mag = require('mag')
-const log = require('five-bells-shared').Log
-const ValueFactory = require('constitute').ValueFactory
+const bunyan = require('bunyan')
+const config = require('./config')
 
-module.exports = new ValueFactory(log(mag, hub))
+function createLogger (name) {
+  const logger = bunyan.createLogger({
+    name: name,
+    level: config.logLevel,
+    stream: process.stdout
+  })
+  return logger
+}
+
+const defaultLogger = createLogger('notary')
+const loggers = [defaultLogger]
+
+function createChildLogger (module) {
+  const logger = defaultLogger.child({
+    module: module
+  })
+  loggers.push(logger)
+  return logger
+}
+
+// For unit testing
+function setOutputStream (outputStream) {
+  loggers.forEach((logger) => {
+    logger.streams = []
+    logger.addStream({
+      type: 'stream',
+      stream: outputStream,
+      level: config.logLevel
+    })
+    logger.currentOutput = outputStream
+  })
+}
+
+defaultLogger.create = createChildLogger
+defaultLogger.setOutputStream = setOutputStream
+module.exports = defaultLogger
+

--- a/src/lib/notificationWorker.js
+++ b/src/lib/notificationWorker.js
@@ -5,7 +5,7 @@ const co = require('co')
 const request = require('co-request')
 const makeCaseAttestation = require('five-bells-shared/utils/makeCaseAttestation')
 const NotificationScheduler = require('five-bells-shared').NotificationScheduler
-const Log = require('./log')
+const log = require('./log')
 const config = require('./config')
 const getCaseByPrimaryKey = require('../models/db/case').getCaseByPrimaryKey
 const updateNotification = require('../models/db/notification').updateNotification
@@ -15,13 +15,13 @@ const notificationDAO = require('../models/db/notification')
 const _ = require('lodash')
 
 class NotificationWorker {
-  static constitute () { return [ Log ] }
-  constructor (log) {
-    this.log = log('notificationWorker')
+  static constitute () { return [] }
+  constructor () {
+    this.log = log.create('notificationWorker')
 
     this.scheduler = new NotificationScheduler({
       notificationDAO,
-      log: log('notificationScheduler'),
+      log: log.create('notificationScheduler'),
       processNotification: this.processNotification.bind(this)
     })
   }

--- a/src/lib/timerWorker.js
+++ b/src/lib/timerWorker.js
@@ -4,16 +4,16 @@ const moment = require('moment')
 const defer = require('co-defer')
 const TimeQueue = require('./timeQueue')
 const CaseExpiryMonitor = require('./caseExpiryMonitor')
-const Log = require('./log')
+const log = require('./log')
 
 const MAX_32INT = 2147483647
 
 class TimerWorker {
-  static constitute () { return [ TimeQueue, CaseExpiryMonitor, Log ] }
-  constructor (timeQueue, caseExpiryMonitor, log) {
+  static constitute () { return [ TimeQueue, CaseExpiryMonitor ] }
+  constructor (timeQueue, caseExpiryMonitor) {
     this.timeQueue = timeQueue
     this.caseExpiryMonitor = caseExpiryMonitor
-    this.log = log('timerWorker')
+    this.log = log.create('timerWorker')
     this.timeout = null
     this.listener = null
   }

--- a/test/healthSpec.js
+++ b/test/healthSpec.js
@@ -3,19 +3,18 @@
 const nock = require('nock')
 nock.enableNetConnect(['localhost', '127.0.0.1'])
 const appHelper = require('./helpers/app')
-const logHelper = require('five-bells-shared/testHelpers/log')
-const Log = require('../src/lib/log')
+const logHelper = require('./helpers/log')
+const log = require('../src/lib/log')
 
 const Container = require('constitute').Container
 const container = new Container()
-const logger = container.constitute(Log)
 
 beforeEach(function * () {
   appHelper.create(this, container)
 })
 
 describe('Health', function () {
-  logHelper(logger)
+  logHelper(log)
 
   describe('GET /health', function () {
     it('should return 200', function * () {

--- a/test/helpers/log.js
+++ b/test/helpers/log.js
@@ -1,0 +1,26 @@
+'use strict'
+
+/* global beforeEach, afterEach */
+
+// This helper captures log output for each test and prints it in case of
+// failure. This means that a successful test run will only print mocha's output
+// whereas a failed run will include more information.
+
+const through = require('through2')
+const format = require('bunyan-format')({outputMode: 'short'})
+
+module.exports = function (logger) {
+  beforeEach(function () {
+    const buffer = through()
+    buffer.pause()
+    logger.setOutputStream(buffer)
+  })
+
+  afterEach(function () {
+    const buffer = logger.currentOutput
+    if (this.currentTest.state !== 'passed') {
+      buffer.pipe(format)
+    }
+    logger.setOutputStream(format)
+  })
+}

--- a/test/metadataSpec.js
+++ b/test/metadataSpec.js
@@ -2,19 +2,18 @@
 
 const expect = require('chai').expect
 const appHelper = require('./helpers/app')
-const logHelper = require('five-bells-shared/testHelpers/log')
-const Log = require('../src/lib/log')
+const logHelper = require('./helpers/log')
+const log = require('../src/lib/log')
 
 const Container = require('constitute').Container
 const container = new Container()
-const logger = container.constitute(Log)
 
 beforeEach(function * () {
   appHelper.create(this, container)
 })
 
 describe('Metadata', function () {
-  logHelper(logger)
+  logHelper(log)
 
   describe('GET /', function () {
     it('should return metadata', function * () {


### PR DESCRIPTION
Related:

- https://github.com/interledger/five-bells-ledger/pull/294
- https://github.com/interledger/five-bells-connector/pull/196

Motivation:
To provide structured, machine-parseable logging for production
deployments.

The bunyan logger will by default log in JSON in one line:

```
 {"name":"koa","hostname":"alan-lm","pid":39269,"req_id":"bbf85791-9169-43bd-a679-4214c8b9cea7","level":30,"req":{"method":"GET","url":"/accounts/test","headers":{"host":"localhost:3001","accept":"application/json","connection":"close"},"remoteAddress":"::ffff:127.0.0.1","remotePort":60024},"res":{"statusCode":200,"header":"HTTP/1.1 200 OK\r\nAccess-Control-Allow-Origin: *\r\nAccess-Control-Expose-Headers: link\r\nAccess-Control-Allow-Methods: GET,HEAD,PUT,POST,DELETE\r\nContent-Type: application/json; charset=utf-8\r\nContent-Length: 162\r\nDate: Tue, 12 Jul 2016 23:49:22 GMT\r\nConnection: close\r\n\r\n"},"duration":9,"msg":"  --> GET /accounts/test 200 9ms","time":"2016-07-12T23:49:22.811Z","v":0}
 ```

This can be parsed for human-readability using a JSON parser such as [`jq`](https://stedolan.github.io/jq/) or the [bunyan CLI](https://github.com/trentm/node-bunyan#cli-usage)

In this commit, `npm start` will by default pipe the JSON output to the
`bunyan` CLI. Example logging looks like:

```
 [2016-07-12T23:49:22.978Z]  INFO: koa/39269 on alan-lm:   <-- GET /connectors (req_id=0053ab9c-de7f-4782-a55f-a33ca6042f58, req.remoteAddress=::ffff:127.0.0.1, req.remotePort=60037)
    GET /connectors HTTP/1.1
    host: localhost:3001
    accept: application/json
    connection: close
[2016-07-12T23:49:22.982Z]  INFO: koa/39269 on alan-lm:   --> GET /connectors 200 4ms (req_id=0053ab9c-de7f-4782-a55f-a33ca6042f58, duration=4, req.remoteAddress=::ffff:127.0.0.1, req.remotePort=60037)
    GET /connectors HTTP/1.1
    host: localhost:3001
    accept: application/json
    connection: close
    --
    HTTP/1.1 200 OK
    HTTP/1.1 200 OK
...
```

Additionally, the request logger will log the `X-Request-ID` header and
store the result in the Koa context as `reqId` (e.g., `this.reqId`).
This is helpful for tracing requests across components (e.g., ledger ->
connector, connector -> ledger, client -> connector -> ledger)
See:
https://github.com/koajs/bunyan-logger#koabunyanloggerrequestidcontextopts

log level can be configured using `NOTARY_LOG_LEVEL` environment
variable. Default is `debug` in test, and `info` otherwise. `trace`
level will log the request and response bodies